### PR TITLE
add zIndex to avoid overlapping with other elements

### DIFF
--- a/DropdownAlert.js
+++ b/DropdownAlert.js
@@ -384,7 +384,8 @@ export default class DropdownAlert extends Component {
               position: 'absolute',
               top: this.state.topValue,
               left: 0,
-              right: 0
+              right: 0,
+              zIndex: 9999
             }}>
             {this.renderStatusBar(this.state.type, backgroundColor)}
             <TouchableHighlight


### PR DESCRIPTION
as you can see dropdown is overlapping with "Title..." TextInput. This is happening on Android. Adding zIndex is fixing this issue.

<img width="400" alt="screen shot 2017-03-06 at 1 16 00 am" src="https://cloud.githubusercontent.com/assets/450140/23593101/b9842c96-020a-11e7-91d5-391807691148.png">
