### PR TITLE
Added support to translucent status bar

### DIFF
--- a/DropdownAlert.js
+++ b/DropdownAlert.js
@@ -43,7 +43,8 @@ export default class DropdownAlert extends Component {
     showCancel: PropTypes.bool,
     tapToCloseEnabled: PropTypes.bool,
     panResponderEnabled: PropTypes.bool,
-    replaceEnabled: PropTypes.bool
+    replaceEnabled: PropTypes.bool,
+    translucent: PropTypes.bool
   }
   static defaultProps =  {
     onClose: null,
@@ -92,7 +93,8 @@ export default class DropdownAlert extends Component {
       width: DEFAULT_IMAGE_DIMENSIONS,
       height: DEFAULT_IMAGE_DIMENSIONS,
       alignSelf: 'center'
-    }
+    },
+    translucent: false
   }
   constructor(props) {
     super(props)
@@ -373,6 +375,11 @@ export default class DropdownAlert extends Component {
           backgroundColor = this.props.successColor
           break;
       }
+
+      if (Platform.OS === 'android' && this.props.translucent) {
+        style = [style, { paddingTop: StatusBar.currentHeight }]
+      }
+
       return (
           <Animated.View
            ref={(ref) => this.mainView = ref}


### PR DESCRIPTION
As discussed here #41, this is a solution to fix the wrong rendering behavior when translucent status bar is set to true. As mentioned there, I'm adding support to pass a translucent boolean property, recommend to be the same passed to StatusBar, to render the component with a additional padding top. 

### Example

```jsx
render() {
    return (
      <View>
        <StatusBar backgroundColor='transparent' translucent={ this.props.translucent } />
        <DropdownAlert
          ref={ ref => this.dropdown = ref }
          showCancel={ true }
          translucent={ this.props.translucent }
        />
      </View>
    )
}
```
Actually, I haven't found a way to ask StatusBar if it was set to translucent out of the box. After reading its code, and checking StatusBarManager interface, I couldn't find a way to retrieve it. Any additional help?