### PR TITLE
Fix pan response cause tap not work on some Android device

### DIFF
--- a/DropdownAlert.js
+++ b/DropdownAlert.js
@@ -45,7 +45,8 @@ export default class DropdownAlert extends Component {
     inactiveStatusBarStyle: PropTypes.string,
     inactiveStatusBarBackgroundColor: PropTypes.string,
     updateStatusBar: PropTypes.bool,
-    elevation: PropTypes.number
+    elevation: PropTypes.number,
+    sensitivity: PropTypes.number,
   }
   static defaultProps =  {
     onClose: null,
@@ -102,6 +103,7 @@ export default class DropdownAlert extends Component {
     inactiveStatusBarBackgroundColor: StatusBarDefaultBackgroundColor,
     updateStatusBar: true,
     elevation: 1,
+    sensitivity: 20,
   }
   constructor(props) {
     super(props)
@@ -302,7 +304,7 @@ export default class DropdownAlert extends Component {
     return this.props.panResponderEnabled
   }
   handleMoveShouldSetPanResponder(e: Object, gestureState: Object): boolean {
-    return gestureState.dx !== 0 && gestureState.dy !== 0 && this.props.panResponderEnabled
+    return Math.abs(gestureState.dx) < this.props.sensitivity && Math.abs(gestureState.dy) >= this.props.sensitivity && this.props.panResponderEnabled
   }
   handlePanResponderMove(e: Object, gestureState: Object) {
     if (gestureState.dy < 0) {

--- a/README.md
+++ b/README.md
@@ -84,5 +84,6 @@ onClose(data) {
 | ```warnColor``` | String  | Default background color of warn message | #cd853f
 | ```errorColor``` | String  | Default background color of error message | #cc3232
 | ```elevation``` | Number  | Animated.View elevation | 1
+| ```sensitivity``` | Number  | Sensitivity for the pan responder up gesture | 20
 
 > Inspired by: [RKDropdownAlert](https://github.com/cwRichardKim/RKDropdownAlert)


### PR DESCRIPTION
I am not able to fire the tap event on some device for example Samsung Note 5. On this device, it is hardly to get gestureState.dx == 0 and gestureState.dy == 0 when the alert in tapped, the value i get is always 0.xxxx. So refer from others, I found that using Math.abs is the best method to solve this problem. 

Refer here:
https://github.com/facebook/react-native/issues/3082#issuecomment-160923562