### PR TITLE
Function dismissDirectly added

### DIFF
--- a/DropdownAlert.js
+++ b/DropdownAlert.js
@@ -239,6 +239,23 @@ export default class DropdownAlert extends Component {
       }.bind(this), (this.state.duration))
     }
   }
+  dismissDirectly() {
+    if (this.state.isOpen) {
+      if (closeTimeoutId != null) {
+        clearTimeout(closeTimeoutId)
+      }
+      this.setState({
+        isOpen: false
+      })
+      if (this.props.updateStatusBar) {
+        if (Platform.OS == 'android') {
+          StatusBar.setBackgroundColor(this.props.inactiveStatusBarBackgroundColor, true)
+        } else {
+          StatusBar.setBarStyle(this.props.inactiveStatusBarStyle, true)
+        }
+      }
+    }
+  }
   onClose(action) {
     if (action == undefined) {
       action = 'programmatic'


### PR DESCRIPTION
PR fixes the warning message "Warning: Can only update a mounted or mounting component" (see [issue](https://github.com/testshallpass/react-native-dropdownalert/issues/82)). 

Before unmounting a component the app must call the function dismissDirectly():

```
componentWillUnmount() {
  this.dropdown.dismissDirectly();
}

render() {
  return(
    <View><Text>Hello world</Text></View>
    <DropdownAlert ref={(ref) => this.dropdown = ref} />  
  )
}
```