### PR TITLE
if StatusBar._defaultProps is not defined (RN Web) fallback to sane defaults.

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,7 +1,7 @@
 import { StatusBar, Platform, Dimensions } from 'react-native';
 
-const StatusBarDefaultBarStyle = StatusBar._defaultProps.barStyle.value;
-const StatusBarDefaultBackgroundColor = StatusBar._defaultProps.backgroundColor.value;
+const StatusBarDefaultBarStyle = StatusBar._defaultProps ? StatusBar._defaultProps.barStyle.value : 'default';
+const StatusBarDefaultBackgroundColor = StatusBar._defaultProps ? StatusBar._defaultProps.backgroundColor.value : 'black';
 const DEFAULT_IMAGE_DIMENSIONS = 36;
 const WINDOW = Dimensions.get('window');
 const HEIGHT = WINDOW.height;


### PR DESCRIPTION
This property does not exist, and StatusBar on RNW is a stub anyway.