### PR TITLE
fix wrong file name

### DIFF
--- a/Example/index.js
+++ b/Example/index.js
@@ -1,4 +1,4 @@
 import React from 'react';
 import { AppRegistry } from 'react-native';
-import Main from './main';
+import Main from './Main';
 AppRegistry.registerComponent('DropDownAlert', () =>  Main );


### PR DESCRIPTION
I got this error message, when I lauched the example.

```
bundling failed: UnableToResolveError: Unable to resolve module `./main` from `/Users/xxx/react-native-dropdownalert/Example/index.js`: could not resolve `/Users/xxx/react-native-dropdownalert/Example/main' as a file nor as a folder
```

PR fix it.