### PR TITLE
Add image source to alert with type function

### DIFF
--- a/DropdownAlert.js
+++ b/DropdownAlert.js
@@ -220,7 +220,7 @@ export default class DropdownAlert extends Component {
         message: message,
         title: title,
         topValue: 0,
-        payload: payload
+        payload: payload || {}
       });
       if (this.state.isOpen == false) {
         this.setState({
@@ -255,7 +255,7 @@ export default class DropdownAlert extends Component {
               title: title,
               isOpen: true,
               topValue: 0,
-              payload: payload
+              payload: payload || {}
             });
           }
           self.animate(1);

--- a/DropdownAlert.js
+++ b/DropdownAlert.js
@@ -156,7 +156,7 @@ export default class DropdownAlert extends Component {
       startDelta: props.startDelta,
       endDelta: props.endDelta,
       topValue: 0,
-      customSource: null
+      payload: {}
     };
     this.types = {
       INFO: 'info',
@@ -203,7 +203,7 @@ export default class DropdownAlert extends Component {
       },
     });
   };
-  alertWithType = (type, title, message, interval, customSource) => {
+  alertWithType = (type, title, message, payload, interval) => {
     if (validateType(type) == false) {
       return;
     }
@@ -220,7 +220,7 @@ export default class DropdownAlert extends Component {
         message: message,
         title: title,
         topValue: 0,
-        customSource
+        payload: payload
       });
       if (this.state.isOpen == false) {
         this.setState({
@@ -255,7 +255,7 @@ export default class DropdownAlert extends Component {
               title: title,
               isOpen: true,
               topValue: 0,
-              customSource
+              payload: payload
             });
           }
           self.animate(1);
@@ -303,6 +303,7 @@ export default class DropdownAlert extends Component {
                 title: this.state.title,
                 message: this.state.message,
                 action: action, // !!! How the alert was closed: automatic, programmatic, tap, pan or cancel
+                payload: this.state.payload,
               };
               onClose(data);
             }
@@ -450,10 +451,10 @@ export default class DropdownAlert extends Component {
     return <Label {...messageTextProps} style={StyleSheet.flatten(messageStyle)} numberOfLines={messageNumOfLines} text={this.state.message} />;
   }
   render() {
-    const { isOpen, type, customSource } = this.state;
+    const { isOpen, type, payload } = this.state;
     if (isOpen) {
       let style = this.getStyleForType(type);
-      const source = customSource || this.getSourceForType(type);
+      const source = payload.customSource || this.getSourceForType(type);
       const backgroundColor = this.getBackgroundColorForType(type);
       let { activeStatusBarBackgroundColor, translucent, updateStatusBar, activeStatusBarStyle, cancelBtnImageSrc, showCancel } = this.props;
       if (IS_ANDROID) {

--- a/DropdownAlert.js
+++ b/DropdownAlert.js
@@ -454,7 +454,7 @@ export default class DropdownAlert extends Component {
     const { isOpen, type, payload } = this.state;
     if (isOpen) {
       let style = this.getStyleForType(type);
-      const source = payload ? (payload.customSource || this.getSourceForType(type)) : this.getSourceForType(type);
+      const source = payload ? payload.customSource : this.getSourceForType(type);
       const backgroundColor = this.getBackgroundColorForType(type);
       let { activeStatusBarBackgroundColor, translucent, updateStatusBar, activeStatusBarStyle, cancelBtnImageSrc, showCancel } = this.props;
       if (IS_ANDROID) {

--- a/DropdownAlert.js
+++ b/DropdownAlert.js
@@ -454,7 +454,7 @@ export default class DropdownAlert extends Component {
     const { isOpen, type, payload } = this.state;
     if (isOpen) {
       let style = this.getStyleForType(type);
-      const source = payload ? payload.customSource : this.getSourceForType(type);
+      const source = payload.customSource ? payload.customSource : this.getSourceForType(type);
       const backgroundColor = this.getBackgroundColorForType(type);
       let { activeStatusBarBackgroundColor, translucent, updateStatusBar, activeStatusBarStyle, cancelBtnImageSrc, showCancel } = this.props;
       if (IS_ANDROID) {

--- a/DropdownAlert.js
+++ b/DropdownAlert.js
@@ -441,14 +441,14 @@ export default class DropdownAlert extends Component {
       return this.props.renderTitle(this.props, this.state);
     }
     const { titleTextProps, titleStyle, titleNumOfLines } = this.props;
-    return <Label {...titleTextProps} style={StyleSheet.flatten(titleStyle)} numberOfLines={titleNumOfLines} text={this.state.title} />;
+    return <Label {...titleTextProps} style={[StyleSheet.flatten(titleStyle), StyleSheet.flatten(this.state.payload.titleStyle || {})]} numberOfLines={titleNumOfLines} text={this.state.title} />;
   }
   renderMessage() {
     if (this.props.renderMessage) {
       return this.props.renderMessage(this.props, this.state);
     }
     const { messageTextProps, messageStyle, messageNumOfLines } = this.props;
-    return <Label {...messageTextProps} style={StyleSheet.flatten(messageStyle)} numberOfLines={messageNumOfLines} text={this.state.message} />;
+    return <Label {...messageTextProps} style={[StyleSheet.flatten(messageStyle), StyleSheet.flatten(this.state.payload.messageStyle || {})]} numberOfLines={messageNumOfLines} text={this.state.message} />;
   }
   render() {
     const { isOpen, type, payload } = this.state;

--- a/DropdownAlert.js
+++ b/DropdownAlert.js
@@ -454,7 +454,7 @@ export default class DropdownAlert extends Component {
     const { isOpen, type, payload } = this.state;
     if (isOpen) {
       let style = this.getStyleForType(type);
-      const source = payload.customSource || this.getSourceForType(type);
+      const source = payload ? (payload.customSource || this.getSourceForType(type)) : this.getSourceForType(type);
       const backgroundColor = this.getBackgroundColorForType(type);
       let { activeStatusBarBackgroundColor, translucent, updateStatusBar, activeStatusBarStyle, cancelBtnImageSrc, showCancel } = this.props;
       if (IS_ANDROID) {

--- a/DropdownAlert.js
+++ b/DropdownAlert.js
@@ -156,6 +156,7 @@ export default class DropdownAlert extends Component {
       startDelta: props.startDelta,
       endDelta: props.endDelta,
       topValue: 0,
+      customSource: null
     };
     this.types = {
       INFO: 'info',
@@ -202,7 +203,7 @@ export default class DropdownAlert extends Component {
       },
     });
   };
-  alertWithType = (type, title, message, interval) => {
+  alertWithType = (type, title, message, interval, customSource) => {
     if (validateType(type) == false) {
       return;
     }
@@ -219,6 +220,7 @@ export default class DropdownAlert extends Component {
         message: message,
         title: title,
         topValue: 0,
+        customSource
       });
       if (this.state.isOpen == false) {
         this.setState({
@@ -253,6 +255,7 @@ export default class DropdownAlert extends Component {
               title: title,
               isOpen: true,
               topValue: 0,
+              customSource
             });
           }
           self.animate(1);
@@ -447,10 +450,10 @@ export default class DropdownAlert extends Component {
     return <Label {...messageTextProps} style={StyleSheet.flatten(messageStyle)} numberOfLines={messageNumOfLines} text={this.state.message} />;
   }
   render() {
-    const { isOpen, type } = this.state;
+    const { isOpen, type, customSource } = this.state;
     if (isOpen) {
       let style = this.getStyleForType(type);
-      const source = this.getSourceForType(type);
+      const source = customSource || this.getSourceForType(type);
       const backgroundColor = this.getBackgroundColorForType(type);
       let { activeStatusBarBackgroundColor, translucent, updateStatusBar, activeStatusBarStyle, cancelBtnImageSrc, showCancel } = this.props;
       if (IS_ANDROID) {

--- a/imageview.js
+++ b/imageview.js
@@ -29,6 +29,9 @@ export default class ImageView extends Component {
       if (!style['height']) {
         style['height'] = DEFAULT_IMAGE_DIMENSIONS;
       }
+      if(isRemote) {
+        style['borderRadius'] = (style['width'] / 2);
+      }
       return <Image style={style} source={isRemote ? { uri: source } : source} {...imageProps} />;
     }
     return null;

--- a/index.d.ts
+++ b/index.d.ts
@@ -65,6 +65,7 @@ export interface DropdownAlertProps {
       type: DropdownAlertType,
       title: string,
       message: string,
+      payload?: object,
       interval?: number
     ): void
   }

--- a/label.js
+++ b/label.js
@@ -5,7 +5,10 @@ import { Text } from 'react-native';
 export default class Label extends Component {
   static propTypes = {
     text: PropTypes.string.isRequired,
-    style: PropTypes.object,
+    style: PropTypes.oneOfType([
+      PropTypes.object,
+      PropTypes.array
+    ]),
     numberOfLines: PropTypes.number,
   };
   static defaultProps = {


### PR DESCRIPTION
It's a simple change 👷 

This change is to put a custom image source in the DropDownAlert menu.

Example: 
```ssh 
myDropDown.alertWithType('info','Test title', 'message', null, require('assets/images/simple-logo.png'));

```
Result:
![image](https://user-images.githubusercontent.com/12767294/52498586-1342b500-2b8e-11e9-82b0-8c4e22be1c3e.png)



