### PR TITLE
Allow user to pass "isInteraction" anim config

### DIFF
--- a/DropdownAlert.js
+++ b/DropdownAlert.js
@@ -38,6 +38,7 @@ export default class DropdownAlert extends Component {
     replaceEnabled: PropTypes.bool,
     translucent: PropTypes.bool,
     useNativeDriver: PropTypes.bool,
+    isInteraction: PropTypes.bool,
     activeStatusBarStyle: PropTypes.string,
     activeStatusBarBackgroundColor: PropTypes.string,
     inactiveStatusBarStyle: PropTypes.string,
@@ -131,6 +132,7 @@ export default class DropdownAlert extends Component {
     inactiveStatusBarBackgroundColor: StatusBarDefaultBackgroundColor,
     updateStatusBar: true,
     useNativeDriver: IS_IOS,
+    isInteraction: undefined,
     elevation: 1,
     zIndex: null,
     sensitivity: 20,
@@ -331,6 +333,7 @@ export default class DropdownAlert extends Component {
       duration: this.state.duration,
       friction: 9,
       useNativeDriver: this.props.useNativeDriver,
+      isInteraction: this.props.isInteraction,
     }).start();
   };
   onLayoutEvent(event) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -31,6 +31,7 @@ export interface DropdownAlertProps {
     replaceEnabled?: boolean
     translucent?: boolean
     useNativeDriver?: boolean
+    isInteraction?: boolean
     activeStatusBarStyle?: string
     activeStatusBarBackgroundColor?: string
     inactiveStatusBarStyle?: string


### PR DESCRIPTION
By default RN animations are considered "interactions". This means during a dropdown alert animation, all InteractionManager.runAfterInteraction() callbacks will be suspended until animation completion.

This PR allows to set isInteraction=false from props and disable this behavior. In my usecase I'd like to avoid delaying the callbacks when a dropdown is animating.

This PR should be retrocompatible (isInteraction=true is default) for users and enable my usecase.

See also 
- https://facebook.github.io/react-native/docs/animated#spring
- https://facebook.github.io/react-native/docs/interactionmanager