### PR TITLE
Put back useNativeDriver: true

### DIFF
--- a/DropdownAlert.js
+++ b/DropdownAlert.js
@@ -130,7 +130,7 @@ export default class DropdownAlert extends Component {
     inactiveStatusBarStyle: StatusBarDefaultBarStyle,
     inactiveStatusBarBackgroundColor: StatusBarDefaultBackgroundColor,
     updateStatusBar: true,
-    useNativeDriver: IS_IOS,
+    useNativeDriver: true,
     elevation: 1,
     zIndex: null,
     sensitivity: 20,


### PR DESCRIPTION
For me it's working fine on Android, are there reasons anymore to not make this the default?