### PR TITLE
add data type for onClose/onCancel

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,8 +23,8 @@ export interface DropdownAlertProps {
     cancelBtnImageStyle?: object | number
     titleNumOfLines?: number
     messageNumOfLines?: number
-    onClose?(): void
-    onCancel?(): void
+    onClose?(data: AlertDataType): void
+    onCancel?(data: AlertDataType): void
     showCancel?: boolean
     tapToCloseEnabled?: boolean
     panResponderEnabled?: boolean
@@ -72,3 +72,17 @@ export interface DropdownAlertProps {
       interval?: number,
     ): void
   }
+export type CloseActionType =
+  | 'automatic'
+  | 'programmatic'
+  | 'tap'
+  | 'pan'
+  | 'cancel'
+export type AlertDataType = {
+  type: DropdownAlertType
+  title: string
+  message: string
+  action: CloseActionType
+  payload: object
+  interval: number
+}


### PR DESCRIPTION
There will be a ts warning because `data` type is missing on onClose and onCancel
```
Type '({ action }: { action: any; }) => void' is not assignable to type '() => void'.ts(2322)
``` 