### PR TITLE
fix closeInterval set to 0 disable auto close

### DIFF
--- a/DropdownAlert.js
+++ b/DropdownAlert.js
@@ -258,7 +258,9 @@ export default class DropdownAlert extends Component {
     if (!replaceEnabled && isOpen) {
       this.alertData = data;
       this.setState({ isOpen: true });
-      this.closeAutomatic(duration);
+      if (duration > 0) {
+        this.closeAutomatic(duration);
+      }
       return;
     }
     if (isOpen) {
@@ -274,7 +276,9 @@ export default class DropdownAlert extends Component {
     this.setState({ isOpen: true });
     this.animate(1, 450, () => {
       this.animationLock = false;
-      this.closeAutomatic(duration);
+      if (duration > 0) {
+        this.closeAutomatic(duration);
+      }
     });
   };
   closeAction = (action = ACTION.programmatic, onDone = () => {}) => {

--- a/__tests__/CancelButton-test.js
+++ b/__tests__/CancelButton-test.js
@@ -4,8 +4,18 @@ import CancelButton from '../CancelButton';
 import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 
-test('CancelButton renders', () => {
-  const wrapper = shallow(<CancelButton />);
-  const tree = toJson(wrapper);
-  expect(tree).toMatchSnapshot();
+describe('CancelButton', () => {
+  test('renders', () => {
+    const wrapper = shallow(<CancelButton />);
+    const tree = toJson(wrapper);
+    expect(tree).toMatchSnapshot();
+  });
+  test('test onPress to be defined', () => {
+    const onCancel = () => {
+      console.log('Cancelled');
+    };
+    const wrapper = shallow(<CancelButton onPress={onCancel} />);
+    expect(wrapper.prop('onPress')).toEqual(onCancel);
+    expect(wrapper.props().onPress).toBeDefined();
+  });
 });

--- a/__tests__/Constants-test.js
+++ b/__tests__/Constants-test.js
@@ -1,20 +1,30 @@
 import { getDefaultStatusBarStyle, getDefaultStatusBarBackgroundColor } from '../constants';
 
-test('StatusBarDefaultBarStyle to be default', () => {
-  const barStyle = getDefaultStatusBarStyle();
-  expect(barStyle).toBe('default');
-});
-test('StatusBarDefaultBackgroundColor to be black', () => {
-  const backgroundColor = getDefaultStatusBarBackgroundColor();
-  expect(backgroundColor).toBe('black');
-});
-test('StatusBarDefaultBarStyle to be StatusBar._defaultProps.barStyle.value', () => {
-  const { StatusBar } = require('react-native');
-  const barStyle = getDefaultStatusBarStyle();
-  expect(barStyle).toBe(StatusBar._defaultProps.barStyle.value);
-});
-test('StatusBarDefaultBackgroundColor to be StatusBar._defaultProps.backgroundColor.value', () => {
-  const { StatusBar } = require('react-native');
-  const backgroundColor = getDefaultStatusBarBackgroundColor();
-  expect(backgroundColor).toBe(StatusBar._defaultProps.backgroundColor.value);
+describe('Constants', () => {
+  describe('Mock StatusBar with no _defaultProps property', () => {
+    beforeEach(() => {
+      jest.mock('StatusBar', () => {
+        return {};
+      });
+    });
+    test('StatusBarDefaultBarStyle to be default', () => {
+      const barStyle = getDefaultStatusBarStyle();
+      expect(barStyle).toBe('default');
+    });
+    test('StatusBarDefaultBackgroundColor to be black', () => {
+      const backgroundColor = getDefaultStatusBarBackgroundColor();
+      expect(backgroundColor).toBe('black');
+    });
+  });
+  describe('StatusBar with _defaultProps property', () => {
+    const { StatusBar } = require('react-native');
+    test('StatusBarDefaultBarStyle to be StatusBar._defaultProps.barStyle.value', () => {
+      const barStyle = getDefaultStatusBarStyle();
+      expect(barStyle).toBe(StatusBar._defaultProps.barStyle.value);
+    });
+    test('StatusBarDefaultBackgroundColor to be StatusBar._defaultProps.backgroundColor.value', () => {
+      const backgroundColor = getDefaultStatusBarBackgroundColor();
+      expect(backgroundColor).toBe(StatusBar._defaultProps.backgroundColor.value);
+    });
+  });
 });

--- a/__tests__/DropdownAlert-test.js
+++ b/__tests__/DropdownAlert-test.js
@@ -173,7 +173,7 @@ describe('DropdownAlert component', () => {
         <DropdownAlert imageSrc={imageSrc} showCancel={true} renderTitle={() => {}} renderMessage={() => {}} renderCancel={() => {}} renderImage={() => {}} />
       );
       wrapper.instance().isOpen = false;
-      wrapper.instance().closeTimeoutID = setTimeout(function() {});
+      wrapper.instance().closeTimeoutID = setTimeout(() => {});
       wrapper.update();
       const type = TYPE.error;
       const title = 'Duis duis nostrud excepteur ipsum.';
@@ -189,7 +189,7 @@ describe('DropdownAlert component', () => {
     test('expect type custom to be open state and have alert data', () => {
       const wrapper = shallow(<DropdownAlert imageSrc={imageSrc} />);
       wrapper.instance().isOpen = false;
-      wrapper.instance().closeTimeoutID = setTimeout(function() {});
+      wrapper.instance().closeTimeoutID = setTimeout(() => {});
       wrapper.update();
       const type = TYPE.custom;
       const title = 'Lorem fugiat reprehenderit non aute elit Lorem quis sit irure non.';
@@ -205,7 +205,7 @@ describe('DropdownAlert component', () => {
     test('expect type info to be open state with replaceEnabled prop as false', () => {
       const wrapper = shallow(<DropdownAlert imageSrc={imageSrc} replaceEnabled={false} />);
       wrapper.instance().isOpen = false;
-      wrapper.instance().closeTimeoutID = setTimeout(function() {});
+      wrapper.instance().closeTimeoutID = setTimeout(() => {});
       wrapper.update();
       const type = TYPE.info;
       const title = 'Laborum reprehenderit aute sit sunt labore velit consectetur cillum id dolore tempor mollit commodo.';
@@ -222,7 +222,7 @@ describe('DropdownAlert component', () => {
       const closeInterval = 4000;
       const wrapper = shallow(<DropdownAlert imageSrc={imageSrc} closeInterval={closeInterval} />);
       wrapper.instance().isOpen = false;
-      wrapper.instance().closeTimeoutID = setTimeout(function() {});
+      wrapper.instance().closeTimeoutID = setTimeout(() => {});
       wrapper.update();
       const type = TYPE.info;
       const title = 'Laborum reprehenderit aute sit sunt labore velit consectetur cillum id dolore tempor mollit commodo.';
@@ -236,10 +236,28 @@ describe('DropdownAlert component', () => {
       expect(wrapper.instance().state.topValue).toBe(0);
       expect(wrapper.instance().closeTimeoutID).toBeDefined();
     });
+    test('expect type info to be open state with closeInterval prop as zero and replaceEnabled false', () => {
+      const closeInterval = 0;
+      const wrapper = shallow(<DropdownAlert imageSrc={imageSrc} closeInterval={closeInterval} replaceEnabled={false} />);
+      wrapper.instance().setState({ isOpen: true });
+      wrapper.instance().closeTimeoutID = setTimeout(() => {});
+      wrapper.update();
+      const type = TYPE.info;
+      const title = 'Laborum reprehenderit aute sit sunt labore velit consectetur cillum id dolore tempor mollit commodo.';
+      const message = 'Aliquip excepteur dolore ipsum exercitation cupidatat incididunt in.';
+      wrapper.instance().alertWithType(type, title, message, {});
+      expect(wrapper.instance().alertData.type).toBe(type);
+      expect(wrapper.instance().alertData.title).toBe(title);
+      expect(wrapper.instance().alertData.message).toBe(message);
+      expect(wrapper.instance().alertData.interval).toBe(closeInterval);
+      expect(wrapper.instance().state.isOpen).toBeTruthy();
+      expect(wrapper.instance().state.topValue).toBe(0);
+      expect(wrapper.instance().closeTimeoutID).toBeDefined();
+    });
     test('expect type success to be open state and have alert data with animationLock as true', () => {
       const wrapper = shallow(<DropdownAlert imageSrc={imageSrc} />);
       wrapper.instance().isOpen = false;
-      wrapper.instance().closeTimeoutID = setTimeout(function() {});
+      wrapper.instance().closeTimeoutID = setTimeout(() => {});
       wrapper.instance().animationLock = true;
       wrapper.update();
       const type = TYPE.success;
@@ -268,7 +286,7 @@ describe('DropdownAlert component', () => {
     test('expect type unknown to be open state and have alert data', () => {
       const wrapper = shallow(<DropdownAlert imageSrc={imageSrc} />);
       wrapper.instance().isOpen = false;
-      wrapper.instance().closeTimeoutID = setTimeout(function() {});
+      wrapper.instance().closeTimeoutID = setTimeout(() => {});
       wrapper.update();
       const type = 'unknown';
       const title = 'Excepteur dolore aute culpa occaecat reprehenderit veniam sint tempor exercitation cillum aliquip id reprehenderit.';
@@ -284,7 +302,7 @@ describe('DropdownAlert component', () => {
     test('expect unknown type to be open state and have alert data and close automatic', () => {
       const wrapper = shallow(<DropdownAlert imageSrc={imageSrc} replaceEnabled={false} />);
       wrapper.instance().setState({ isOpen: true });
-      wrapper.instance().closeTimeoutID = setTimeout(function() {});
+      wrapper.instance().closeTimeoutID = setTimeout(() => {});
       wrapper.update();
       const type = 'unknown';
       const title = 'Excepteur dolore aute culpa occaecat reprehenderit veniam sint tempor exercitation cillum aliquip id reprehenderit.';
@@ -300,7 +318,7 @@ describe('DropdownAlert component', () => {
     test('expect unknown type to be open state and have alert data and close action', () => {
       const wrapper = shallow(<DropdownAlert imageSrc={imageSrc} />);
       wrapper.instance().setState({ isOpen: true });
-      wrapper.instance().closeTimeoutID = setTimeout(function() {});
+      wrapper.instance().closeTimeoutID = setTimeout(() => {});
       wrapper.update();
       const type = 'unknown';
       const title = 'Excepteur dolore aute culpa occaecat reprehenderit veniam sint tempor exercitation cillum aliquip id reprehenderit.';
@@ -314,7 +332,13 @@ describe('DropdownAlert component', () => {
       expect(wrapper.instance().closeTimeoutID).toBeDefined();
     });
   });
-  describe('open', () => {});
+  describe('open', () => {
+    test('expect open to be okay with no data', () => {
+      const wrapper = shallow(<DropdownAlert imageSrc={imageSrc}  />);
+      wrapper.instance().open();
+      expect(wrapper.instance().state.isOpen).toBeTruthy();
+    });
+  });
   describe('closeAction', () => {
     test('expect close with programmatic action to set isOpen to be false', () => {
       const wrapper = shallow(<DropdownAlert imageSrc={imageSrc} />);
@@ -331,6 +355,11 @@ describe('DropdownAlert component', () => {
         expect(wrapper.instance().state.isOpen).toBeFalsy();
         expect(wrapper.instance().state.topValue).toBe(0);
       });
+    });
+    test('expect close without action to be okay', () => {
+      const wrapper = shallow(<DropdownAlert imageSrc={imageSrc} />);
+      wrapper.setState({ isOpen: true });
+      wrapper.instance().closeAction();
     });
   });
   describe('closeAutomatic', () => {
@@ -354,6 +383,10 @@ describe('DropdownAlert component', () => {
       const wrapper = shallow(<DropdownAlert imageSrc={imageSrc} />);
       wrapper.instance().updateStatusBar(false, true);
     });
+    test('expect without parameters to be okay', () => {
+      const wrapper = shallow(<DropdownAlert imageSrc={imageSrc} />);
+      wrapper.instance().updateStatusBar();
+    });
   });
   describe('clearCloseTimeoutID', () => {});
   describe('animate', () => {
@@ -362,6 +395,12 @@ describe('DropdownAlert component', () => {
       wrapper.instance().animate(1, 450, () => {})
       const lock = wrapper.instance().animationLock;
       expect(lock).toBeTruthy();
+    });
+    test('expect animation lock to be false', () => {
+      const wrapper = shallow(<DropdownAlert imageSrc={imageSrc} useAnimationLock={false} />);
+      wrapper.instance().animate(0)
+      const lock = wrapper.instance().animationLock;
+      expect(lock).toBeFalsy();
     });
   });
   describe('getStartDelta', () => {

--- a/docs/PROPS.md
+++ b/docs/PROPS.md
@@ -33,7 +33,7 @@
 
 | Name | Type | Description | Default |
 | ---- | :---: | --- | --- |
-| ```closeInterval``` | Number  | automatic close duration in milliseconds (set to 0 disables the automatic close) | 4000
+| ```closeInterval``` | Number  | automatic close duration in milliseconds (set to less than and equal to 0 disables the automatic close) | 4000
 | ```startDelta``` | Number  | where the alert container starts to animate from (min: negative height) | -100
 | ```endDelta``` | Number  | where the alert container ends at | 0
 | ```useAnimationLock``` | Bool | used to avoid animation collision (i.e. alert is invoked while one is animating open or close) | true

--- a/docs/PROPS.md
+++ b/docs/PROPS.md
@@ -33,7 +33,7 @@
 
 | Name | Type | Description | Default |
 | ---- | :---: | --- | --- |
-| ```closeInterval``` | Number  | automatic close duration in milliseconds | 4000
+| ```closeInterval``` | Number  | automatic close duration in milliseconds (set to 0 disables the automatic close) | 4000
 | ```startDelta``` | Number  | where the alert container starts to animate from (min: negative height) | -100
 | ```endDelta``` | Number  | where the alert container ends at | 0
 | ```useAnimationLock``` | Bool | used to avoid animation collision (i.e. alert is invoked while one is animating open or close) | true


### PR DESCRIPTION
* Fixes #202 
* `closeInterval` prop set to less than or equal to 0 will disable automatic close. It can still be close by action or programmatically with `closeAction`. 