### PR TITLE
Types - updating the global d.ts with onTap

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,6 +23,7 @@ export interface DropdownAlertProps {
     cancelBtnImageStyle?: object | number
     titleNumOfLines?: number
     messageNumOfLines?: number
+    onTap?(data: AlertDataType): void
     onClose?(data: AlertDataType): void
     onCancel?(data: AlertDataType): void
     showCancel?: boolean


### PR DESCRIPTION
In this PR i simply introduced the missing reference of onTap action on the index.d.ts file. 

This was an issue till now if you were using typescript project the typescript compiler yield that there was not an onTap props.