### PR TITLE
Remove safeAreaStyle prop from type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,6 @@ export interface DropdownAlertProps {
     endDelta?: number
     wrapperStyle?: object | number
     containerStyle?: object | number
-    safeAreaStyle?: object | number
     titleStyle?: object | number
     messageStyle?: object | number
     imageStyle?: object | number


### PR DESCRIPTION
- Remove deprecated `safeAreaStyle` prop from type definitions