### PR TITLE
fix documentation for use with stack navigator

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ export default App;
 ## Caveats
 
 - Modals can overlap DropdownAlert if it is not inside the modal's document tree.
-- It is important you place the `DropdownAlert` **ABOVE** the `StackNavigator`.
+- It is important you place the `DropdownAlert` **BELOW** the `StackNavigator`.
 - [DropdownHolder example #1](https://gist.github.com/testshallpass/d76c656874e417bef4e0e6a63fc492af)
 - [DropdownHolder example #2](https://gist.github.com/testshallpass/6c6c867269348c485a1e0d6ae3f55e90)
 - [Redux + router flux example](https://gist.github.com/testshallpass/13f047205d1b966f55340b8962fe99c0)


### PR DESCRIPTION
putting the dropdown above the stack navigator doesn't render anything